### PR TITLE
Configure custom package registry in package.json

### DIFF
--- a/rajkumar-tailor-ui-v2/package.json
+++ b/rajkumar-tailor-ui-v2/package.json
@@ -34,5 +34,8 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~5.0.2"
+  },
+  "publishConfig": {
+    "@marotiuppe:registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
This commit adds a custom registry configuration to the package.json file. The custom registry is set to the GitHub package registry for the "@marotiuppe" scope.

Changes Made:
- Added "publishConfig" entry to package.json.
- Configured custom registry for the "@marotiuppe" scope.